### PR TITLE
Fix country sorting for antd area select.

### DIFF
--- a/src/area-select.lite.tsx
+++ b/src/area-select.lite.tsx
@@ -2,7 +2,7 @@ import Select, { SelectProps } from 'rc-select';
 import { OptionProps } from 'rc-select/es/Option';
 import React, { useContext } from 'react';
 import { configContext } from './config';
-import { filterOption, filterSort } from './shared';
+import { filterOption } from './shared';
 
 export interface AreaSelectProps extends SelectProps<any> {
   optionProps?: OptionProps;
@@ -13,6 +13,12 @@ export const AreaSelect = ({
   ...selectProps
 }: AreaSelectProps) => {
   const { areas } = useContext(configContext);
+
+  const filterSort: SelectProps['filterSort'] = (a, b) => {
+    const keyA = a.key as string;
+    const keyB = b.key as string;
+    return keyA.length - keyB.length;
+  };
 
   return (
     <Select

--- a/src/area-select.lite.tsx
+++ b/src/area-select.lite.tsx
@@ -14,12 +14,6 @@ export const AreaSelect = ({
 }: AreaSelectProps) => {
   const { areas } = useContext(configContext);
 
-  const filterSort: SelectProps['filterSort'] = (a, b) => {
-    const keyA = a.key as string;
-    const keyB = b.key as string;
-    return keyA.length - keyB.length;
-  };
-
   return (
     <Select
       showArrow
@@ -27,7 +21,6 @@ export const AreaSelect = ({
       dropdownMatchSelectWidth={false}
       optionLabelProp="label"
       filterOption={filterOption}
-      filterSort={filterSort}
       {...selectProps}
     >
       {areas.map((item) => {

--- a/src/area-select.tsx
+++ b/src/area-select.tsx
@@ -2,7 +2,7 @@ import { Select } from 'antd';
 import { OptionProps, SelectProps } from 'antd/es/select';
 import React, { useContext } from 'react';
 import { configContext } from './config';
-import { filterOption, filterSort } from './shared';
+import { filterOption } from './shared';
 
 export interface AreaSelectProps extends SelectProps<any> {
   optionProps?: OptionProps;
@@ -28,7 +28,6 @@ export const AreaSelect = ({
         dropdownMatchSelectWidth={false}
         optionLabelProp="label"
         filterOption={filterOption}
-        filterSort={filterSort}
         {...selectProps}
       >
         {areas.map((item) => {

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -47,13 +47,27 @@ export type AreaMapper = (value: Area, index: number, array: Area[]) => Area;
 export type AreaSorter = (a: Area, b: Area) => number;
 const defaultAreaFilter: AreaFilter = () => true;
 const defaultAreaMapper: AreaMapper = (area) => area;
+const defaultAreaSorter: AreaSorter = (a, b) => {
+  if (a.name && b.name) {
+    const nameA = a.name.toUpperCase();
+    const nameB = b.name.toUpperCase();
+    if (nameA < nameB) {
+      return -1;
+    }
+    if (nameA > nameB) {
+      return 1;
+    }
+    return 0;
+  }
+  return 0;
+};
 
 export const ConfigProvider = ({
   children,
   locale = {},
   areaFilter = defaultAreaFilter,
   areaMapper = defaultAreaMapper,
-  areaSorter,
+  areaSorter = defaultAreaSorter,
 }: {
   children: ReactNode;
   locale?: any;

--- a/src/shared.tsx
+++ b/src/shared.tsx
@@ -15,12 +15,6 @@ export const filterOption: SelectProps['filterOption'] = (input, option) => {
   return keyHasAllChars;
 };
 
-export const filterSort: SelectProps['filterSort'] = (a, b) => {
-  const keyA = a.key as string;
-  const keyB = b.key as string;
-  return keyA.length - keyB.length;
-};
-
 export const usePhoneInput = ({
   isControlled,
   defaultValue,


### PR DESCRIPTION
Solves #58 

There are two points of this PR:

`filterSort` function file was not shaped correctly for the `world_countries_lists` package used in primary example of this library - it tried to sort by a non-existing key property, instead by name. 

It was overwriting any sorting provided by areaSorter prop of a <ConfigProvider>.

Because alphabetical sorting of countries in a prefix dropdown should be a default behaviour, i set a function from [example](https://boyuai.github.io/antd-country-phone-input/demos/custom-sorter) to be a `defaultAreaSorter`.
 
I have not changed the implementation for a _lite_ version, but i think it should be adjusted as well and finally, we should distinguish it between the lite and antd versions, as typing of their filtering functions is a bit different. That is why i moved `filterSort` function from `./shared` to `area-select.lite`.